### PR TITLE
Flag init as unavailable

### DIFF
--- a/Robot/Public/Proxies/RBTableViewCellsProxy.h
+++ b/Robot/Public/Proxies/RBTableViewCellsProxy.h
@@ -21,6 +21,8 @@
 @property (nonatomic) UITableViewScrollPosition preferredScrollPosition;
 
 + (instancetype)cellsFromTableView:(UITableView *)tableView;
+
+- (instancetype)init __attribute__((unavailable("Must use -initWithTableView:")));
 - (instancetype)initWithTableView:(UITableView *)tableView;
 
 /*! Returns a table view cell at the given index path

--- a/Robot/Public/Proxies/RBTableViewCellsProxy.m
+++ b/Robot/Public/Proxies/RBTableViewCellsProxy.m
@@ -26,12 +26,6 @@
     return self;
 }
 
-- (instancetype)init
-{
-    [self doesNotRecognizeSelector:_cmd];
-    return nil;
-}
-
 #pragma mark - Public
 
 - (id)cellForRow:(NSUInteger)row inSection:(NSUInteger)section


### PR DESCRIPTION
Hey @jeffh ,
This is trivial PR with an alternative to `doesNotRecognizeSelector:`. The real purpose is to say that Robot is looking awesome!  You figured out the real solution to a weird keyboard timing issue I was having in FRY (another KIF alternative), and I dig the DSL design!   Looking forward to what happens when this and FOX collide.

:+1: 